### PR TITLE
Fix incorrect password complexity display

### DIFF
--- a/src/main/java/me/goral/keepmypassworddesktop/controllers/MainAppController.java
+++ b/src/main/java/me/goral/keepmypassworddesktop/controllers/MainAppController.java
@@ -295,8 +295,10 @@ public class MainAppController {
 
         tf.textProperty().bindBidirectional(password.textProperty());
 
-        Label pwdCheck = new Label(MainApp.lang.getString("no-password-info"));
-        pwdCheck.setTextFill(Color.web("#b3b3b3"));//NON-NLS
+        Label pwdCheck = new Label();
+        Pair<String, Color> initComplexity = checkPasswordComplexity(passwordString);
+        pwdCheck.setText(initComplexity.getKey());
+        pwdCheck.setTextFill(initComplexity.getValue());
 
         password.textProperty().addListener((observable, oldValue, newValue) -> {
             Pair<String, Color> res = checkPasswordComplexity(newValue);


### PR DESCRIPTION
After registering with weak password, the app shows "Password is not strong enough" and shows the register dialog again. This dialog contains previous username and password, but it shows "No password" under the password. So I make this pull request to fix it.